### PR TITLE
Inst

### DIFF
--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1580,6 +1580,7 @@ class CompletionResponseChoice(OpenAIBaseModel):
 class EventOut(OpenAIBaseModel):
     event_type: str
     timestamp: float
+    step: Optional[int] = None
 
 class CompletionResponse(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"cmpl-{random_uuid()}")

--- a/vllm/entrypoints/openai/protocol.py
+++ b/vllm/entrypoints/openai/protocol.py
@@ -1577,6 +1577,9 @@ class CompletionResponseChoice(OpenAIBaseModel):
     prompt_logprobs: Optional[list[Optional[dict[int, Logprob]]]] = None
     prompt_token_ids: Optional[list[int]] = None  # For prompt
 
+class EventOut(OpenAIBaseModel):
+    event_type: str
+    timestamp: float
 
 class CompletionResponse(OpenAIBaseModel):
     id: str = Field(default_factory=lambda: f"cmpl-{random_uuid()}")
@@ -1592,6 +1595,8 @@ class CompletionResponse(OpenAIBaseModel):
     # vLLM-specific fields that are not in OpenAI spec
     kv_transfer_params: Optional[dict[str, Any]] = Field(
         default=None, description="KVTransfer parameters.")
+    
+    events: list[EventOut] = []
 
 
 class CompletionResponseStreamChoice(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -313,7 +313,10 @@ class OpenAIServingCompletion(OpenAIServing):
                 yield "data: [DONE]\n\n"
 
             return fake_stream_generator()
-
+        
+        server_left_event = EventOut(event_type="SERVER_LEFT", timestamp=time.monotonic())
+        response.events.append(server_left_event)
+        
         return response
 
     async def completion_stream_generator(
@@ -518,7 +521,7 @@ class OpenAIServingCompletion(OpenAIServing):
         events = None 
 
         for final_res in final_res_batch:
-            events=[EventOut(event_type=e.type.name, timestamp=e.timestamp) for e in final_res.events]
+            events=[EventOut(event_type=e.type.name, timestamp=e.timestamp, step=e.step) for e in final_res.events]
             
             last_final_res = final_res
             prompt_token_ids = final_res.prompt_token_ids

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -93,6 +93,8 @@ class OpenAIServingCompletion(OpenAIServing):
             - suffix (the language models we currently support do not support
             suffix)
         """
+        server_hit_event = EventOut(event_type="SERVER_HIT", timestamp=time.monotonic())
+
         error_check_ret = await self._check_model(request)
         if error_check_ret is not None:
             return error_check_ret
@@ -293,6 +295,8 @@ class OpenAIServingCompletion(OpenAIServing):
                 tokenizer,
                 request_metadata,
             )
+            response.events.append(server_hit_event)
+
         except asyncio.CancelledError:
             return self.create_error_response("Client disconnected")
         except ValueError as e:

--- a/vllm/entrypoints/openai/serving_completion.py
+++ b/vllm/entrypoints/openai/serving_completion.py
@@ -22,7 +22,8 @@ from vllm.entrypoints.openai.protocol import (CompletionLogProbs,
                                               CompletionResponseChoice,
                                               CompletionResponseStreamChoice,
                                               CompletionStreamResponse,
-                                              ErrorResponse,
+                                              ErrorResponse, 
+                                              EventOut,
                                               PromptTokenUsageInfo,
                                               RequestResponseMetadata,
                                               UsageInfo)
@@ -510,7 +511,11 @@ class OpenAIServingCompletion(OpenAIServing):
         num_generated_tokens = 0
         kv_transfer_params = None
         last_final_res = None
+        events = None 
+
         for final_res in final_res_batch:
+            events=[EventOut(event_type=e.type.name, timestamp=e.timestamp) for e in final_res.events]
+            
             last_final_res = final_res
             prompt_token_ids = final_res.prompt_token_ids
             assert prompt_token_ids is not None
@@ -601,6 +606,7 @@ class OpenAIServingCompletion(OpenAIServing):
             choices=choices,
             usage=usage,
             kv_transfer_params=kv_transfer_params,
+            events=events
         )
 
     def _create_completion_logprobs(

--- a/vllm/outputs.py
+++ b/vllm/outputs.py
@@ -119,6 +119,7 @@ class RequestOutput:
         *,
         multi_modal_placeholders: Optional[MultiModalPlaceholderDict] = None,
         kv_transfer_params: Optional[dict[str, Any]] = None,
+        events = None,
         # Forward compatibility, code that uses args added in new release can
         # still run with older versions of vLLM without breaking.
         **kwargs: Any,
@@ -139,6 +140,7 @@ class RequestOutput:
         self.encoder_prompt_token_ids = encoder_prompt_token_ids
         self.num_cached_tokens = num_cached_tokens
         self.kv_transfer_params = kv_transfer_params
+        self.events = events
 
     def add(self, next_output: "RequestOutput", aggregate: bool) -> None:
         """Merge subsequent RequestOutput into this one"""

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -111,9 +111,7 @@ class CachedRequestData:
 
 @dataclass
 class SchedulerMetrics:
-    num_finished_reqs: int = 0
     num_decode_reqs: int = 0
-    num_finished_tokens: int = 0
     num_cache_miss_tokens: int = 0
     num_cache_hit_tokens: int = 0
     step_index: int = 0

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -110,6 +110,15 @@ class CachedRequestData:
 
 
 @dataclass
+class SchedulerMetrics:
+    num_finished_reqs: int = 0
+    num_decode_reqs: int = 0
+    num_finished_tokens: int = 0
+    num_cache_miss_tokens: int = 0
+    num_cache_hit_tokens: int = 0
+    step_index: int = 0
+
+@dataclass
 class SchedulerOutput:
 
     # list of the requests that are scheduled for the first time.
@@ -155,3 +164,6 @@ class SchedulerOutput:
 
     # KV Cache Connector metadata.
     kv_connector_metadata: Optional[KVConnectorMetadata] = None
+    
+    # MERt: scheduler metrics
+    metrics: Optional[SchedulerMetrics] = None

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -265,7 +265,7 @@ class Scheduler(SchedulerInterface):
                     request,
                     num_new_tokens,
                     num_lookahead_tokens=self.num_lookahead_tokens)
-                if new_blocks is None or self.STEP % 2 == 0:
+                if new_blocks is None:
                     # The request cannot be scheduled.
                     # Preempt the lowest-priority request.
                     if self.policy == SchedulingPolicy.PRIORITY:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -432,6 +432,12 @@ class Scheduler(SchedulerInterface):
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
 
+
+                    if (0 < self.scheduler_config.long_prefill_token_threshold
+                            < num_new_tokens):
+                        num_new_tokens = (
+                            self.scheduler_config.long_prefill_token_threshold)
+                        
                     ## MERT num_cache_miss_tokens and num_cache_hit_tokens: 
                     # num_new_tokens is cache MISS, and num_computed_tokens is CACHE HIT -- 
                     # decode - you have no CACHE MISS
@@ -441,11 +447,6 @@ class Scheduler(SchedulerInterface):
                     # Misses only during prefill
                     if request.num_computed_tokens < request.num_prompt_tokens:
                         num_cache_miss_tokens += num_new_tokens
-
-                    if (0 < self.scheduler_config.long_prefill_token_threshold
-                            < num_new_tokens):
-                        num_new_tokens = (
-                            self.scheduler_config.long_prefill_token_threshold)
 
                     # chunked prefill has to be enabled explicitly to allow
                     # pooling requests to be chunked

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -265,7 +265,7 @@ class Scheduler(SchedulerInterface):
                     request,
                     num_new_tokens,
                     num_lookahead_tokens=self.num_lookahead_tokens)
-                if new_blocks is None:
+                if new_blocks is None or self.STEP % 2 == 0:
                     # The request cannot be scheduled.
                     # Preempt the lowest-priority request.
                     if self.policy == SchedulingPolicy.PRIORITY:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -22,7 +22,7 @@ from vllm.v1.core.encoder_cache_manager import (EncoderCacheManager,
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.sched.interface import SchedulerInterface
 from vllm.v1.core.sched.output import (CachedRequestData, NewRequestData,
-                                       SchedulerOutput)
+                                       SchedulerOutput, SchedulerMetrics)
 from vllm.v1.core.sched.request_queue import (SchedulingPolicy,
                                               create_request_queue)
 from vllm.v1.core.sched.utils import check_stop, remove_all
@@ -188,6 +188,12 @@ class Scheduler(SchedulerInterface):
         # and the "jump decoding" optimization in the future.
         self.STEP += 1
 
+        num_finished_reqs = 0
+        num_decode_reqs = 0
+        num_finished_tokens = 0
+        num_cache_miss_tokens = 0
+        num_cache_hit_tokens = 0
+
         scheduled_new_reqs: list[Request] = []
         scheduled_resumed_reqs: list[Request] = []
         scheduled_running_reqs: list[Request] = []
@@ -213,6 +219,11 @@ class Scheduler(SchedulerInterface):
             num_new_tokens = (request.num_tokens_with_spec +
                               request.num_output_placeholders -
                               request.num_computed_tokens)
+            
+            # MERT num_decode_reqs: if num_new_tokens == 1 and num_computed_tokens > num_prompt_tokens, then this is decode request 
+            if num_new_tokens == 1 and request.num_computed_tokens >= request.num_prompt_tokens: 
+                num_decode_reqs = num_decode_reqs + 1
+
             if (0 < self.scheduler_config.long_prefill_token_threshold <
                     num_new_tokens):
                 num_new_tokens = (
@@ -292,12 +303,19 @@ class Scheduler(SchedulerInterface):
                 break
             assert new_blocks is not None
 
+            # MERT: Cache accounting for running requests
+            num_cache_hit_tokens += request.num_computed_tokens
+            if request.num_computed_tokens < request.num_prompt_tokens:
+                num_cache_miss_tokens += num_new_tokens
+
             # Schedule the request.
             scheduled_running_reqs.append(request)
             req_to_new_blocks[request.request_id] = new_blocks
             num_scheduled_tokens[request.request_id] = num_new_tokens
             token_budget -= num_new_tokens
             req_index += 1
+
+
 
             # Speculative decode related.
             if request.spec_token_ids:
@@ -413,6 +431,17 @@ class Scheduler(SchedulerInterface):
                     # `request.num_prompt_tokens` to consider the resumed
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
+
+                    ## MERT num_cache_miss_tokens and num_cache_hit_tokens: 
+                    # num_new_tokens is cache MISS, and num_computed_tokens is CACHE HIT -- 
+                    # decode - you have no CACHE MISS
+                    # Always count hits
+                    num_cache_hit_tokens += request.num_computed_tokens
+
+                    # Misses only during prefill
+                    if request.num_computed_tokens < request.num_prompt_tokens:
+                        num_cache_miss_tokens += num_new_tokens
+
                     if (0 < self.scheduler_config.long_prefill_token_threshold
                             < num_new_tokens):
                         num_new_tokens = (
@@ -575,6 +604,25 @@ class Scheduler(SchedulerInterface):
         structured_output_request_ids, grammar_bitmask = (
             self.get_grammar_bitmask(self.running,
                                      scheduled_spec_decode_tokens))
+        
+
+        # MERT: self.finished_req_ids - len will give # of finished requests
+        # iterate over request ids, and get from requests, and num_computed_tokens of each requests sum them up
+        for req_id in self.finished_req_ids:
+            req = self.requests.get(req_id)
+            if req is not None:
+                num_finished_tokens += req.num_computed_tokens
+
+        # Pack into SchedulerMetrics
+        metrics = SchedulerMetrics(
+            num_finished_reqs=num_finished_reqs,
+            num_decode_reqs=num_decode_reqs,
+            num_finished_tokens=num_finished_tokens,
+            num_cache_miss_tokens=num_cache_miss_tokens,
+            num_cache_hit_tokens=num_cache_hit_tokens,
+            step_index=self.STEP,
+        )
+
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
             scheduled_cached_reqs=cached_reqs_data,
@@ -592,6 +640,7 @@ class Scheduler(SchedulerInterface):
             get_freed_mm_hashes(),
             structured_output_request_ids=structured_output_request_ids,
             grammar_bitmask=grammar_bitmask,
+            metrics=metrics
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -503,6 +503,7 @@ class Scheduler(SchedulerInterface):
                 if self.log_stats:
                     request.record_event(EngineCoreEventType.SCHEDULED,
                                          scheduled_timestamp)
+                
                 if request.status == RequestStatus.WAITING:
                     scheduled_new_reqs.append(request)
                 elif request.status == RequestStatus.PREEMPTED:
@@ -916,6 +917,9 @@ class Scheduler(SchedulerInterface):
                                      pooler_output)
 
             if stopped:
+                if self.log_stats:
+                    request.record_event(EngineCoreEventType.FINISHED, time.monotonic())
+                    
                 kv_transfer_params = self._free_request(request)
                 if status_before_stop == RequestStatus.RUNNING:
                     stopped_running_reqs.add(request)
@@ -1077,7 +1081,7 @@ class Scheduler(SchedulerInterface):
         self.waiting.add_request(request)
         self.requests[request.request_id] = request
         if self.log_stats:
-            request.record_event(EngineCoreEventType.QUEUED)
+            request.record_event(EngineCoreEventType.QUEUED, time.monotonic())
 
     def finish_requests(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -49,6 +49,7 @@ class Scheduler(SchedulerInterface):
         include_finished_set: bool = False,
         log_stats: bool = False,
     ) -> None:
+        self.STEP: int = 0  # class variable to track schedule() calls
         self.vllm_config = vllm_config
         self.scheduler_config = vllm_config.scheduler_config
         self.cache_config = vllm_config.cache_config
@@ -185,6 +186,7 @@ class Scheduler(SchedulerInterface):
         # num_tokens_with_spec. This is general enough to cover
         # chunked prefills, prefix caching, speculative decoding,
         # and the "jump decoding" optimization in the future.
+        self.STEP += 1
 
         scheduled_new_reqs: list[Request] = []
         scheduled_resumed_reqs: list[Request] = []
@@ -274,7 +276,7 @@ class Scheduler(SchedulerInterface):
                     preempted_req.num_computed_tokens = 0
                     if self.log_stats:
                         preempted_req.record_event(
-                            EngineCoreEventType.PREEMPTED, scheduled_timestamp)
+                            EngineCoreEventType.PREEMPTED, scheduled_timestamp, self.STEP)
 
                     self.waiting.prepend_request(preempted_req)
                     preempted_reqs.append(preempted_req)
@@ -502,7 +504,7 @@ class Scheduler(SchedulerInterface):
                 self.running.append(request)
                 if self.log_stats:
                     request.record_event(EngineCoreEventType.SCHEDULED,
-                                         scheduled_timestamp)
+                                         scheduled_timestamp, self.STEP)
                 
                 if request.status == RequestStatus.WAITING:
                     scheduled_new_reqs.append(request)
@@ -918,7 +920,7 @@ class Scheduler(SchedulerInterface):
 
             if stopped:
                 if self.log_stats:
-                    request.record_event(EngineCoreEventType.FINISHED, time.monotonic())
+                    request.record_event(EngineCoreEventType.FINISHED, time.monotonic(), self.STEP)
                     
                 kv_transfer_params = self._free_request(request)
                 if status_before_stop == RequestStatus.RUNNING:
@@ -1081,7 +1083,7 @@ class Scheduler(SchedulerInterface):
         self.waiting.add_request(request)
         self.requests[request.request_id] = request
         if self.log_stats:
-            request.record_event(EngineCoreEventType.QUEUED, time.monotonic())
+            request.record_event(EngineCoreEventType.QUEUED, time.monotonic(), self.STEP)
 
     def finish_requests(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -220,9 +220,7 @@ class Scheduler(SchedulerInterface):
                               request.num_output_placeholders -
                               request.num_computed_tokens)
             
-            # MERT num_decode_reqs: if num_new_tokens == 1 and num_computed_tokens > num_prompt_tokens, then this is decode request 
-            if num_new_tokens == 1 and request.num_computed_tokens >= request.num_prompt_tokens: 
-                num_decode_reqs = num_decode_reqs + 1
+
 
             if (0 < self.scheduler_config.long_prefill_token_threshold <
                     num_new_tokens):
@@ -302,6 +300,10 @@ class Scheduler(SchedulerInterface):
             if not can_schedule:
                 break
             assert new_blocks is not None
+
+            # MERT num_decode_reqs: if num_new_tokens == 1 and num_computed_tokens > num_prompt_tokens, then this is decode request 
+            if num_new_tokens == 1 and request.num_computed_tokens >= request.num_prompt_tokens: 
+                num_decode_reqs = num_decode_reqs + 1
 
             # MERT: Cache accounting for running requests
             num_cache_hit_tokens += request.num_computed_tokens
@@ -443,16 +445,6 @@ class Scheduler(SchedulerInterface):
                             < num_new_tokens):
                         num_new_tokens = (
                             self.scheduler_config.long_prefill_token_threshold)
-                        
-                    ## MERT num_cache_miss_tokens and num_cache_hit_tokens: 
-                    # num_new_tokens is cache MISS, and num_computed_tokens is CACHE HIT -- 
-                    # decode - you have no CACHE MISS
-                    # Always count hits
-                    num_cache_hit_tokens += request.num_computed_tokens
-
-                    # Misses only during prefill
-                    if request.num_computed_tokens < request.num_prompt_tokens:
-                        num_cache_miss_tokens += num_new_tokens
 
                     # chunked prefill has to be enabled explicitly to allow
                     # pooling requests to be chunked
@@ -463,6 +455,16 @@ class Scheduler(SchedulerInterface):
                         continue
 
                     num_new_tokens = min(num_new_tokens, token_budget)
+
+                    ## MERT num_cache_miss_tokens and num_cache_hit_tokens: 
+                    # num_new_tokens is cache MISS, and num_computed_tokens is CACHE HIT -- 
+                    # decode - you have no CACHE MISS
+                    # Always count hits
+                    num_cache_hit_tokens += request.num_computed_tokens
+
+                    # Misses only during prefill
+                    if request.num_computed_tokens < request.num_prompt_tokens:
+                        num_cache_miss_tokens += num_new_tokens
                     assert num_new_tokens > 0
 
                     # Schedule encoder inputs.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -188,9 +188,9 @@ class Scheduler(SchedulerInterface):
         # and the "jump decoding" optimization in the future.
         self.STEP += 1
 
-        num_finished_reqs = 0
+        self.num_finished_reqs = 0
         num_decode_reqs = 0
-        num_finished_tokens = 0
+        self.num_finished_tokens = 0
         num_cache_miss_tokens = 0
         num_cache_hit_tokens = 0
 
@@ -604,20 +604,10 @@ class Scheduler(SchedulerInterface):
         structured_output_request_ids, grammar_bitmask = (
             self.get_grammar_bitmask(self.running,
                                      scheduled_spec_decode_tokens))
-        
-
-        # MERT: self.finished_req_ids - len will give # of finished requests
-        # iterate over request ids, and get from requests, and num_computed_tokens of each requests sum them up
-        for req_id in self.finished_req_ids:
-            req = self.requests.get(req_id)
-            if req is not None:
-                num_finished_tokens += req.num_computed_tokens
 
         # Pack into SchedulerMetrics
         metrics = SchedulerMetrics(
-            num_finished_reqs=num_finished_reqs,
             num_decode_reqs=num_decode_reqs,
-            num_finished_tokens=num_finished_tokens,
             num_cache_miss_tokens=num_cache_miss_tokens,
             num_cache_hit_tokens=num_cache_hit_tokens,
             step_index=self.STEP,
@@ -903,7 +893,7 @@ class Scheduler(SchedulerInterface):
         self,
         scheduler_output: SchedulerOutput,
         model_runner_output: ModelRunnerOutput,
-    ) -> dict[int, EngineCoreOutputs]:
+    ) -> tuple[dict[int, EngineCoreOutputs], int, int]:
         sampled_token_ids = model_runner_output.sampled_token_ids
         logprobs = model_runner_output.logprobs
         prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict
@@ -1059,7 +1049,7 @@ class Scheduler(SchedulerInterface):
                 engine_core_outputs[0] = eco = EngineCoreOutputs()
             eco.scheduler_stats = stats
 
-        return engine_core_outputs
+        return engine_core_outputs, self.num_finished_tokens, self.num_finished_reqs
 
     def _update_request_with_output(
         self,
@@ -1181,6 +1171,7 @@ class Scheduler(SchedulerInterface):
     def _free_request(self, request: Request) -> Optional[dict[str, Any]]:
         assert request.is_finished()
 
+
         delay_free_blocks, kv_xfer_params = self._connector_finished(request)
         self.encoder_cache_manager.free(request)
         request_id = request.request_id
@@ -1190,6 +1181,10 @@ class Scheduler(SchedulerInterface):
 
         if not delay_free_blocks:
             self._free_blocks(request)
+
+        # MERT: update finished tokens
+        self.num_finished_tokens += request.num_computed_tokens
+        self.num_finished_reqs += 1
 
         return kv_xfer_params
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -394,12 +394,18 @@ class Scheduler(SchedulerInterface):
                 num_external_computed_tokens = 0
                 load_kv_async = False
 
+
+                # MERT: 
                 # Get already-cached tokens.
                 if request.num_computed_tokens == 0:
                     # Get locally-cached tokens.
                     new_computed_blocks, num_new_local_computed_tokens = \
                         self.kv_cache_manager.get_computed_blocks(
                             request)
+                    
+                    if self.log_stats:
+                        request.record_event(EngineCoreEventType.PREFIX,
+                                            None, num_new_local_computed_tokens)
 
                     # Get externally-cached tokens if using a KVConnector.
                     if self.connector is not None:

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -83,13 +83,15 @@ class EngineCoreEvent(msgspec.Struct):
     """
     type: EngineCoreEventType
     timestamp: float
+    step: Optional[int] = None   # make step optional
 
     @classmethod
     def new_event(cls,
                   event_type: EngineCoreEventType,
-                  timestamp: Optional[float] = None) -> "EngineCoreEvent":
+                  timestamp: Optional[float] = None,
+                  step: Optional[int] = None) -> "EngineCoreEvent":
         timestamp = time.monotonic() if timestamp is None else timestamp
-        return cls(event_type, timestamp)
+        return cls(event_type, timestamp, step)
 
 
 class EngineCoreOutput(

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -73,6 +73,7 @@ class EngineCoreEventType(enum.IntEnum):
     SCHEDULED = 2
     PREEMPTED = 3
     FINISHED = 4
+    PREFIX = 5
 
 class EngineCoreEvent(msgspec.Struct):
     """A timestamped engine core event associated with a request.

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -72,7 +72,7 @@ class EngineCoreEventType(enum.IntEnum):
     QUEUED = 1
     SCHEDULED = 2
     PREEMPTED = 3
-
+    FINISHED = 4
 
 class EngineCoreEvent(msgspec.Struct):
     """A timestamped engine core event associated with a request.

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -784,18 +784,18 @@ class EngineCoreProc(EngineCore):
         # Loop until process is sent a SIGINT or SIGTERM
         while True:
             # 1) Poll the input queue until there is work to do.
-            start_time = time.monotonic()
-            print(f"----- [Busy loop start, timestamp: {start_time}]")
             self._process_input_queue()
 
             # 2) Step the engine core and return the outputs.
             print(f"----- [Busy loop process engine step]")
+            start_time = time.monotonic()
+            print(f"----- [Busy loop start, timestamp: {start_time}]")
             ran_model = self._process_engine_step()
             end_time = time.monotonic()
            
             # MERT: record loop execution time ONLY FOR WHEN THERE IS REQS. 
-            
             loop_time = end_time - start_time
+            
             print(f"----- [Busy loop end, timestamp: {end_time} and start was {start_time}] and diff {loop_time}")
 
             # Only record loop time if scheduler had requests

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -56,6 +56,8 @@ logger = init_logger(__name__)
 POLLING_TIMEOUT_S = 2.5
 HANDSHAKE_TIMEOUT_MINS = 5
 
+VLLM_INST_METRICS = {}
+
 _R = TypeVar('_R')  # Return type for collective_rpc
 
 
@@ -289,6 +291,20 @@ class EngineCore:
         if not self.scheduler.has_requests():
             return {}, False
         scheduler_output = self.scheduler.schedule()
+        ## MERT: get metrics from scheduler_output
+        metrics = scheduler_output.metrics
+
+        # Populate metrics dict, keyed by step_index
+        VLLM_INST_METRICS[metrics.step_index] = {
+            "num_finished_reqs": metrics.num_finished_reqs,
+            "num_decode_reqs": metrics.num_decode_reqs,
+            "num_finished_tokens": metrics.num_finished_tokens,
+            "num_cache_miss_tokens": metrics.num_cache_miss_tokens,
+            "num_cache_hit_tokens": metrics.num_cache_hit_tokens,
+            # loop_time will be filled in EngineCoreProc
+            "loop_time": None,
+        }
+
         model_output = self.execute_model_with_error_logging(
             self.model_executor.execute_model,  # type: ignore
             scheduler_output)
@@ -727,15 +743,37 @@ class EngineCoreProc(EngineCore):
     def _init_data_parallel(self, vllm_config: VllmConfig):
         pass
 
+    def mert_print_metrics(self, metrics_dict):
+        for step, vals in sorted(metrics_dict.items()):
+            print(f"--- step {step} ---")
+            for k, v in vals.items():
+                print(f"{k} = {v}")
+            print()  # blank line between steps
+
     def run_busy_loop(self):
         """Core busy loop of the EngineCore."""
 
         # Loop until process is sent a SIGINT or SIGTERM
         while True:
             # 1) Poll the input queue until there is work to do.
+            start_time = time.perf_counter()
             self._process_input_queue()
+
             # 2) Step the engine core and return the outputs.
-            self._process_engine_step()
+            ran_model = self._process_engine_step()
+            end_time = time.perf_counter()
+            # MERT: record loop execution time ONLY FOR WHEN THERE IS REQS. 
+            loop_time = end_time - start_time
+
+            # Only record loop time if scheduler had requests
+            if ran_model:
+                # last step_index = max key in VLLM_INST_METRICS
+                if VLLM_INST_METRICS:
+                    last_step = max(VLLM_INST_METRICS.keys())
+                    VLLM_INST_METRICS[last_step]["loop_time"] = loop_time
+            self.mert_print_metrics(VLLM_INST_METRICS)
+
+
 
     def _process_input_queue(self):
         """Exits when an engine step needs to be performed."""

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -294,22 +294,23 @@ class EngineCore:
         ## MERT: get metrics from scheduler_output
         metrics = scheduler_output.metrics
 
+        model_output = self.execute_model_with_error_logging(
+            self.model_executor.execute_model,  # type: ignore
+            scheduler_output)
+        engine_core_outputs, num_finished_tokens, num_finished_reqs = self.scheduler.update_from_output(
+            scheduler_output, model_output)  # type: ignore
+        
+
         # Populate metrics dict, keyed by step_index
         VLLM_INST_METRICS[metrics.step_index] = {
-            "num_finished_reqs": metrics.num_finished_reqs,
+            "num_finished_reqs": num_finished_reqs,
             "num_decode_reqs": metrics.num_decode_reqs,
-            "num_finished_tokens": metrics.num_finished_tokens,
+            "num_finished_tokens": num_finished_tokens,
             "num_cache_miss_tokens": metrics.num_cache_miss_tokens,
             "num_cache_hit_tokens": metrics.num_cache_hit_tokens,
             # loop_time will be filled in EngineCoreProc
             "loop_time": None,
         }
-
-        model_output = self.execute_model_with_error_logging(
-            self.model_executor.execute_model,  # type: ignore
-            scheduler_output)
-        engine_core_outputs = self.scheduler.update_from_output(
-            scheduler_output, model_output)  # type: ignore
 
         return (engine_core_outputs,
                 scheduler_output.total_num_scheduled_tokens > 0)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -58,9 +58,11 @@ POLLING_TIMEOUT_S = 2.5
 HANDSHAKE_TIMEOUT_MINS = 5
 
 VLLM_INST_METRICS = {}
-FLUSH_INTERVAL_STEPS = 20
+FLUSH_INTERVAL_STEPS = int(os.getenv("FLUSH_INTERVAL_STEPS", 20))
+metrics_part = os.getenv("METRICS_FILENAME_PREFIX", "metrics")
 
-def flush_metrics(metrics_dict, last_step, filepath="metrics_{}.json"):
+
+def flush_metrics(metrics_dict, last_step, filepath="{}_{}.json"):
     # Use last_step to create a unique filename
     file_name = filepath.format(last_step)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -59,12 +59,12 @@ HANDSHAKE_TIMEOUT_MINS = 5
 
 VLLM_INST_METRICS = {}
 FLUSH_INTERVAL_STEPS = int(os.getenv("FLUSH_INTERVAL_STEPS", 20))
-metrics_part = os.getenv("METRICS_FILENAME_PREFIX", "metrics")
+METRICS_FILENAME = os.getenv("METRICS_FILENAME", "metrics")
 
 
 def flush_metrics(metrics_dict, last_step, filepath="{}_{}.json"):
     # Use last_step to create a unique filename
-    file_name = filepath.format(last_step)
+    file_name = filepath.format(METRICS_FILENAME, last_step)
 
     with open(file_name, "a") as f:
         # Write the metrics as a JSON object with an indent for readability

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -392,6 +392,9 @@ class EngineCore:
         return engine_core_outputs, model_executed
 
     def shutdown(self):
+        # MERT: record/flush all data upon shutdown
+        last_step = max(VLLM_INST_METRICS.keys())
+        flush_metrics(VLLM_INST_METRICS, last_step)
         self.structured_output_manager.clear_backend()
         if self.model_executor:
             self.model_executor.shutdown()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Optional, TypeVar, Union
 
 import msgspec
 import zmq
+import json
 
 from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import stateless_destroy_torch_distributed_process_group
@@ -57,6 +58,19 @@ POLLING_TIMEOUT_S = 2.5
 HANDSHAKE_TIMEOUT_MINS = 5
 
 VLLM_INST_METRICS = {}
+FLUSH_INTERVAL_STEPS = 20
+
+def flush_metrics(metrics_dict, last_step, filepath="metrics_{}.json"):
+    # Use last_step to create a unique filename
+    file_name = filepath.format(last_step)
+
+    with open(file_name, "a") as f:
+        # Write the metrics as a JSON object with an indent for readability
+        json.dump(metrics_dict, f, indent=2)
+        f.write("\n")  # Ensure each entry is on a new line
+
+    # Clear the dictionary to free memory
+    metrics_dict.clear()
 
 _R = TypeVar('_R')  # Return type for collective_rpc
 
@@ -773,6 +787,11 @@ class EngineCoreProc(EngineCore):
                     last_step = max(VLLM_INST_METRICS.keys())
                     VLLM_INST_METRICS[last_step]["loop_time"] = loop_time
             self.mert_print_metrics(VLLM_INST_METRICS)
+
+            # flush metrics periodically
+            last_step = max(VLLM_INST_METRICS.keys())
+            if last_step % FLUSH_INTERVAL_STEPS == 0:
+                flush_metrics(VLLM_INST_METRICS, last_step)
 
 
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -401,6 +401,7 @@ class EngineCore:
 
     def shutdown(self):
         # MERT: record/flush all data upon shutdown
+        print("---- Shutting down vLLM - flush last metrics")
         last_step = max(VLLM_INST_METRICS.keys())
         flush_metrics(VLLM_INST_METRICS, last_step)
         self.structured_output_manager.clear_backend()

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -791,7 +791,7 @@ class EngineCoreProc(EngineCore):
                 if VLLM_INST_METRICS:
                     last_step = max(VLLM_INST_METRICS.keys())
                     VLLM_INST_METRICS[last_step]["loop_time"] = loop_time
-            self.mert_print_metrics(VLLM_INST_METRICS)
+            # self.mert_print_metrics(VLLM_INST_METRICS)
 
             # flush metrics periodically
             last_step = max(VLLM_INST_METRICS.keys())

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -776,12 +776,12 @@ class EngineCoreProc(EngineCore):
         # Loop until process is sent a SIGINT or SIGTERM
         while True:
             # 1) Poll the input queue until there is work to do.
-            start_time = time.perf_counter()
+            start_time = time.monotonic()
             self._process_input_queue()
 
             # 2) Step the engine core and return the outputs.
             ran_model = self._process_engine_step()
-            end_time = time.perf_counter()
+            end_time = time.monotonic()
             # MERT: record loop execution time ONLY FOR WHEN THERE IS REQS. 
             loop_time = end_time - start_time
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -307,22 +307,22 @@ class EngineCore:
         if not self.scheduler.has_requests():
             return {}, False
         
-        print(f"----- [Core step schedule]")
+        # print(f"----- [Core step schedule]")
         scheduler_output = self.scheduler.schedule()
-        print(f"----- [Core step schedule done]")
+        # print(f"----- [Core step schedule done]")
         ## MERT: get metrics from scheduler_output
         metrics = scheduler_output.metrics
 
-        print(f"----- [Core step execture model]")
+        # print(f"----- [Core step execture model]")
         model_output = self.execute_model_with_error_logging(
             self.model_executor.execute_model,  # type: ignore
             scheduler_output)
         
-        print(f"----- [Core step execture model done]")
+        # print(f"----- [Core step execture model done]")
         engine_core_outputs, num_finished_tokens, num_finished_reqs = self.scheduler.update_from_output(
             scheduler_output, model_output)  # type: ignore
         
-        print(f"----- [Core step update from output complete]")
+        # print(f"----- [Core step update from output complete]")
         
 
         # Populate metrics dict, keyed by step_index
@@ -787,23 +787,23 @@ class EngineCoreProc(EngineCore):
             self._process_input_queue()
 
             # 2) Step the engine core and return the outputs.
-            print(f"----- [Busy loop process engine step]")
+            # print(f"----- [Busy loop process engine step]")
             start_time = time.monotonic()
-            print(f"----- [Busy loop start, timestamp: {start_time}]")
+            # print(f"----- [Busy loop start, timestamp: {start_time}]")
             ran_model = self._process_engine_step()
             end_time = time.monotonic()
            
             # MERT: record loop execution time ONLY FOR WHEN THERE IS REQS. 
             loop_time = end_time - start_time
             
-            print(f"----- [Busy loop end, timestamp: {end_time} and start was {start_time}] and diff {loop_time}")
+            # print(f"----- [Busy loop end, timestamp: {end_time} and start was {start_time}] and diff {loop_time}")
 
             # Only record loop time if scheduler had requests
             if ran_model:
                 # last step_index = max key in VLLM_INST_METRICS
                 if VLLM_INST_METRICS:
                     last_step = max(VLLM_INST_METRICS.keys())
-                    print(f"----- [Busy loop end last step {last_step}")
+                    # print(f"----- [Busy loop end last step {last_step}")
                     VLLM_INST_METRICS[last_step]["loop_time"] = loop_time
             # self.mert_print_metrics(VLLM_INST_METRICS)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -306,15 +306,23 @@ class EngineCore:
         # or finished and not yet removed from the batch.
         if not self.scheduler.has_requests():
             return {}, False
+        
+        print(f"----- [Core step schedule]")
         scheduler_output = self.scheduler.schedule()
+        print(f"----- [Core step schedule done]")
         ## MERT: get metrics from scheduler_output
         metrics = scheduler_output.metrics
 
+        print(f"----- [Core step execture model]")
         model_output = self.execute_model_with_error_logging(
             self.model_executor.execute_model,  # type: ignore
             scheduler_output)
+        
+        print(f"----- [Core step execture model done]")
         engine_core_outputs, num_finished_tokens, num_finished_reqs = self.scheduler.update_from_output(
             scheduler_output, model_output)  # type: ignore
+        
+        print(f"----- [Core step update from output complete]")
         
 
         # Populate metrics dict, keyed by step_index
@@ -777,19 +785,25 @@ class EngineCoreProc(EngineCore):
         while True:
             # 1) Poll the input queue until there is work to do.
             start_time = time.monotonic()
+            print(f"----- [Busy loop start, timestamp: {start_time}]")
             self._process_input_queue()
 
             # 2) Step the engine core and return the outputs.
+            print(f"----- [Busy loop process engine step]")
             ran_model = self._process_engine_step()
             end_time = time.monotonic()
+           
             # MERT: record loop execution time ONLY FOR WHEN THERE IS REQS. 
+            
             loop_time = end_time - start_time
+            print(f"----- [Busy loop end, timestamp: {end_time}] and diff {loop_time}")
 
             # Only record loop time if scheduler had requests
             if ran_model:
                 # last step_index = max key in VLLM_INST_METRICS
                 if VLLM_INST_METRICS:
                     last_step = max(VLLM_INST_METRICS.keys())
+                    print(f"----- [Busy loop end last step {last_step}")
                     VLLM_INST_METRICS[last_step]["loop_time"] = loop_time
             # self.mert_print_metrics(VLLM_INST_METRICS)
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -796,7 +796,7 @@ class EngineCoreProc(EngineCore):
             # MERT: record loop execution time ONLY FOR WHEN THERE IS REQS. 
             
             loop_time = end_time - start_time
-            print(f"----- [Busy loop end, timestamp: {end_time}] and diff {loop_time}")
+            print(f"----- [Busy loop end, timestamp: {end_time} and start was {start_time}] and diff {loop_time}")
 
             # Only record loop time if scheduler had requests
             if ran_model:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -401,9 +401,10 @@ class EngineCore:
 
     def shutdown(self):
         # MERT: record/flush all data upon shutdown
-        print("---- Shutting down vLLM - flush last metrics")
+        print("---- Shutting down vLLM - flushing last metrics")
         last_step = max(VLLM_INST_METRICS.keys())
         flush_metrics(VLLM_INST_METRICS, last_step)
+        print("---- Shutting down vLLM - flushed last metrics")
         self.structured_output_manager.clear_backend()
         if self.model_executor:
             self.model_executor.shutdown()

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -168,6 +168,7 @@ class RequestState:
         finish_reason: Optional[FinishReason],
         stop_reason: Union[int, str, None],
         kv_transfer_params: Optional[dict[str, Any]] = None,
+        events = None,
     ) -> Optional[Union[RequestOutput, PoolingRequestOutput]]:
 
         finished = finish_reason is not None
@@ -195,7 +196,7 @@ class RequestState:
                 return None
 
         return self._new_request_output(request_id, outputs, finished,
-                                        kv_transfer_params)
+                                        kv_transfer_params, events)
 
     def _new_request_output(
         self,
@@ -203,6 +204,7 @@ class RequestState:
         outputs: Union[list[CompletionOutput], list[PoolingOutput]],
         finished: bool,
         kv_transfer_params: Optional[dict[str, Any]] = None,
+        events = None
     ) -> Union[RequestOutput, PoolingRequestOutput]:
 
         first_output = outputs[0]
@@ -230,6 +232,7 @@ class RequestState:
             finished=finished,
             kv_transfer_params=kv_transfer_params,
             num_cached_tokens=self.num_cached_tokens,
+            events = events
         )
 
     def _new_completion_output(
@@ -399,6 +402,7 @@ class OutputProcessor:
             kv_transfer_params = engine_core_output.kv_transfer_params
             req_state.num_cached_tokens = engine_core_output.num_cached_tokens
             req_state.is_prefilling = False
+            events = engine_core_output.events
 
             if pooling_output is None:
                 assert req_state.detokenizer is not None
@@ -418,7 +422,7 @@ class OutputProcessor:
             # 4) Create and handle RequestOutput objects.
             if request_output := req_state.make_request_output(
                     new_token_ids, pooling_output, finish_reason, stop_reason,
-                    kv_transfer_params):
+                    kv_transfer_params, events):
                 if req_state.queue is not None:
                     # AsyncLLM: put into queue for handling by generate().
                     req_state.queue.put(request_output)

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -186,11 +186,13 @@ class Request:
         timestamp: Optional[float] = None,
     ) -> None:
         self.events.append(EngineCoreEvent.new_event(event_type, timestamp))
+        print(f"----- [Request {self.request_id} event: {event_type.name}, timestamp: {timestamp}]")
 
     def take_events(self) -> Optional[list[EngineCoreEvent]]:
         if not self.events:
             return None
-        events, self.events = self.events, []
+        # events, self.events = self.events, []
+        events = self.events
         return events
 
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -187,7 +187,7 @@ class Request:
         step: Optional[int] = None,
     ) -> None:
         self.events.append(EngineCoreEvent.new_event(event_type, timestamp, step))
-        # print(f"----- [Request {self.request_id} event: {event_type.name}, timestamp: {timestamp}, step: {step}]")
+        print(f"----- [Request {self.request_id} event: {event_type.name}, timestamp: {timestamp}, step: {step}]")
 
     def take_events(self) -> Optional[list[EngineCoreEvent]]:
         if not self.events:

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -184,9 +184,10 @@ class Request:
         self,
         event_type: EngineCoreEventType,
         timestamp: Optional[float] = None,
+        step: Optional[int] = None,
     ) -> None:
-        self.events.append(EngineCoreEvent.new_event(event_type, timestamp))
-        print(f"----- [Request {self.request_id} event: {event_type.name}, timestamp: {timestamp}]")
+        self.events.append(EngineCoreEvent.new_event(event_type, timestamp, step))
+        print(f"----- [Request {self.request_id} event: {event_type.name}, timestamp: {timestamp}, step: {step}]")
 
     def take_events(self) -> Optional[list[EngineCoreEvent]]:
         if not self.events:

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -187,7 +187,7 @@ class Request:
         step: Optional[int] = None,
     ) -> None:
         self.events.append(EngineCoreEvent.new_event(event_type, timestamp, step))
-        print(f"----- [Request {self.request_id} event: {event_type.name}, timestamp: {timestamp}, step: {step}]")
+        # print(f"----- [Request {self.request_id} event: {event_type.name}, timestamp: {timestamp}, step: {step}]")
 
     def take_events(self) -> Optional[list[EngineCoreEvent]]:
         if not self.events:


### PR DESCRIPTION
- Added FINISHED and SERVER_HIT events (previously only QUEUED and SCHEDULED were recorded).
- Modified the record_event method to log these events with both name and timestamp.
- Since these logs are written on the server (which may not be ideal for Dia’s scripts), I also extended the implementation so that request events are included in the response object. I believe this will be more useful than (2).


- With (2), logs now look like this:
```
(EngineCore_DP0 pid=825085) ----- [Request cmpl-10c18508859146ffb4e5f198b57de243-0 event: QUEUED, timestamp: 3812008.898924067]
(EngineCore_DP0 pid=825085) ----- [Request cmpl-10c18508859146ffb4e5f198b57de243-0 event: SCHEDULED, timestamp: 3812008.899103111]
(EngineCore_DP0 pid=825085) ----- [Request cmpl-10c18508859146ffb4e5f198b57de243-0 event: FINISHED, timestamp: 3812008.921621433]
```

- With (3), the response object now includes events:
```json
{
  "id": "...",
  "object": "...",
  "created": ...,
  "model": "...",
  "choices": [...],
  "service_tier": ...,
  "system_fingerprint": "...",
  "usage": {...},
  "kv_transfer_params": ...,
  "events": [
    {
      "event_type": "QUEUED",
      "timestamp": 3812008.898924067
    },
    {
      "event_type": "SCHEDULED",
      "timestamp": 3812008.899103111
    },
    {
      "event_type": "FINISHED",
      "timestamp": 3812008.921621433
    }
  ]
}
```


- use Mert's vLLM branch
```bash
pip uninstall -y vllm
git clone -b inst https://github.com/toslali-ibm/vllm.git
VLLM_USE_PRECOMPILED=1 pip install -e vllm
```

- start vllm openai server
```bash
python3 -m vllm.entrypoints.openai.api_server \
  --model "Qwen/Qwen2.5-0.5B" \
  --gpu-memory-utilization 0.90 \
  --max-model-len 2048 \
  --max-num-batched-tokens 2048 \ 
```


- send a request 
```bash
curl http://localhost:8000/v1/completions   -H "Content-Type: application/json"   -d '{
    "model": "Qwen/Qwen2.5-0.5B",
    "prompt": "Once upon a time in Boston,",
    "max_tokens": 2
  }'
```

- send concurrent requests:
```bash
seq 2 | xargs -n1 -P2 curl -s http://localhost:8000/v1/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen2.5-0.5B","prompt":"Once upon a time in Boston,","max_tokens":2}'
```